### PR TITLE
Don't assume HTML structure for .wp-smiley

### DIFF
--- a/emoji.css
+++ b/emoji.css
@@ -9,6 +9,6 @@ img.emoji {
 	padding: 0 !important;
 }
 
-.page-content img.wp-smiley, .entry-content img.wp-smiley, .comment-content img.wp-smiley {
+img.wp-smiley {
 	height: 1em;
 }


### PR DESCRIPTION
Removing HTML structure assumptions in emoji.css.

Let me know if the specificity is needed and I'll change the selector to `img.wp-smiley.wp-smiley`
